### PR TITLE
Support sending custom headers

### DIFF
--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -161,7 +161,7 @@ Future<PreviewData> getPreviewData(
   String text, {
   String? proxy,
   Duration? requestTimeout,
-  String? userAgent,
+  Map<String, String>? requestHeaders,
 }) async {
   const previewData = PreviewData();
 
@@ -194,9 +194,9 @@ Future<PreviewData> getPreviewData(
     }
     previewDataUrl = _calculateUrl(url, proxy);
     final uri = Uri.parse(previewDataUrl);
-    final response = await http.get(uri, headers: {
-      'User-Agent': userAgent ?? 'WhatsApp/2',
-    }).timeout(requestTimeout ?? const Duration(seconds: 5));
+    final response = await http
+        .get(uri, headers: requestHeaders)
+        .timeout(requestTimeout ?? const Duration(seconds: 5));
     final document = parser.parse(utf8.decode(response.bodyBytes));
 
     final imageRegexp = RegExp(regexImageContentType);

--- a/lib/src/widgets/link_preview.dart
+++ b/lib/src/widgets/link_preview.dart
@@ -37,6 +37,7 @@ class LinkPreview extends StatefulWidget {
     this.textWidget,
     this.userAgent,
     required this.width,
+    this.requestHeaders,
   });
 
   /// Expand animation duration.
@@ -93,6 +94,9 @@ class LinkPreview extends StatefulWidget {
   /// Pass saved [PreviewData] here so [LinkPreview] would not fetch preview
   /// data again.
   final PreviewData? previewData;
+
+  /// Custom headers to send with the request.
+  final Map<String, String>? requestHeaders;
 
   /// Request timeout after which the request will be cancelled. Defaults to 5 seconds.
   final Duration? requestTimeout;
@@ -257,7 +261,7 @@ class _LinkPreviewState extends State<LinkPreview>
       text,
       proxy: widget.corsProxy,
       requestTimeout: widget.requestTimeout,
-      userAgent: widget.userAgent,
+      requestHeaders: widget.requestHeaders,
     );
     await _handlePreviewDataFetched(previewData);
     return previewData;


### PR DESCRIPTION
## Summary
This PR adds support for sending custom request headers with the GET request for the resource. In our case, we need to pass our Firebase ID token because our proxy is authenticated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/continua-ai/forked_flutter_link_previewer/1)
<!-- Reviewable:end -->
